### PR TITLE
add service.sh

### DIFF
--- a/service.sh
+++ b/service.sh
@@ -1,0 +1,1 @@
+/system/bin/adbd &>/dev/null


### PR DESCRIPTION
fixes "no devices/emulators found" by manually starting adbd (since the system seems to kill the modified version on boot)